### PR TITLE
Add support for Mac OS X

### DIFF
--- a/src/github.com/oniony/TMSU/cli/commands_darwin.go
+++ b/src/github.com/oniony/TMSU/cli/commands_darwin.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// +build !windows,!darwin
+// +build darwin
 
 package cli
 
@@ -30,15 +30,12 @@ var commands = []*Command{
 	&InfoCommand,
 	&InitCommand,
 	&MergeCommand,
-	&MountCommand,
 	&RenameCommand,
 	&RepairCommand,
 	&StatusCommand,
 	&TagCommand,
 	&TagsCommand,
-	&UnmountCommand,
 	&UntagCommand,
 	&UntaggedCommand,
 	&ValuesCommand,
-	&VersionCommand,
-	&VfsCommand}
+	&VersionCommand}

--- a/src/github.com/oniony/TMSU/cli/mount.go
+++ b/src/github.com/oniony/TMSU/cli/mount.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// +build !windows
+// +build !windows,!darwin
 
 package cli
 

--- a/src/github.com/oniony/TMSU/cli/unmount.go
+++ b/src/github.com/oniony/TMSU/cli/unmount.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// +build !windows
+// +build !windows,!darwin
 
 package cli
 

--- a/src/github.com/oniony/TMSU/cli/vfs.go
+++ b/src/github.com/oniony/TMSU/cli/vfs.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// +build !windows
+// +build !windows,!darwin
 
 package cli
 

--- a/src/github.com/oniony/TMSU/vfs/fusevfs.go
+++ b/src/github.com/oniony/TMSU/vfs/fusevfs.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// +build !windows
+// +build !windows,!darwin
 
 package vfs
 

--- a/src/github.com/oniony/TMSU/vfs/mtable.go
+++ b/src/github.com/oniony/TMSU/vfs/mtable.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// +build !windows
+// +build !windows,!darwin
 
 package vfs
 
@@ -27,7 +27,7 @@ import (
 	"strings"
 )
 
-// +build !windows
+// +build !windows,!darwin
 
 type Mount struct {
 	DatabasePath string


### PR DESCRIPTION
This adds very minimal changes to support building on Mac OS X. Essentially omitting the same components as windows (FUSE) is enough to use it on OS X as well. Building is the same as the unix build instructions in COMPILING.md.

The only additional change I would recommend is to have the default install path be /usr/local rooted instead of /usr.  On OS X it will actually forbid you to modify /usr/bin directly even as root.  I wasn't sure if that change would be accepted though, so I have omitted it from this PR.