### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,14 +51,14 @@ dist: compile
 	@echo "PACKAGING DISTRIBUTABLE"
 	@echo
 	@mkdir -p $(DIST_DIR)
+	@mkdir -p $(DIST_DIR)/bin
+	@mkdir -p $(DIST_DIR)/man
+	@mkdir -p $(DIST_DIR)/misc/zsh
 	cp -R bin -T $(DIST_DIR)
 	cp README.md -t $(DIST_DIR)
 	cp COPYING.md -t $(DIST_DIR)
-	@mkdir -p $(DIST_DIR)/bin
 	cp misc/bin/* -t $(DIST_DIR)/bin/
-	@mkdir -p $(DIST_DIR)/man
 	gzip -fc misc/man/tmsu.1 >$(DIST_DIR)/man/tmsu.1.gz
-	@mkdir -p $(DIST_DIR)/misc/zsh
 	cp misc/zsh/_tmsu -t $(DIST_DIR)/misc/zsh/
 	tar czf $(DIST_FILE) $(DIST_DIR)
 
@@ -68,12 +68,12 @@ install:
 	@echo
 	mkdir -p $(INSTALL_DIR)
 	mkdir -p $(MOUNT_INSTALL_DIR)
+	mkdir -p $(MAN_INSTALL_DIR)
+	mkdir -p $(ZSH_COMP_INSTALL_DIR)
 	cp bin/tmsu -t $(INSTALL_DIR)
 	cp misc/bin/mount.tmsu -t $(MOUNT_INSTALL_DIR)
 	cp misc/bin/tmsu-* -t $(INSTALL_DIR)
-	mkdir -p $(MAN_INSTALL_DIR)
 	gzip -fc misc/man/tmsu.1 >$(MAN_INSTALL_DIR)/tmsu.1.gz
-	mkdir -p $(ZSH_COMP_INSTALL_DIR)
 	cp misc/zsh/_tmsu -t $(ZSH_COMP_INSTALL_DIR)
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -51,28 +51,30 @@ dist: compile
 	@echo "PACKAGING DISTRIBUTABLE"
 	@echo
 	@mkdir -p $(DIST_DIR)
-	cp -R bin $(DIST_DIR)
-	cp README.md $(DIST_DIR)
-	cp COPYING.md $(DIST_DIR)
+	cp -R bin -T $(DIST_DIR)
+	cp README.md -t $(DIST_DIR)
+	cp COPYING.md -t $(DIST_DIR)
 	@mkdir -p $(DIST_DIR)/bin
-	cp misc/bin/* $(DIST_DIR)/bin/
+	cp misc/bin/* -t $(DIST_DIR)/bin/
 	@mkdir -p $(DIST_DIR)/man
 	gzip -fc misc/man/tmsu.1 >$(DIST_DIR)/man/tmsu.1.gz
 	@mkdir -p $(DIST_DIR)/misc/zsh
-	cp misc/zsh/_tmsu $(DIST_DIR)/misc/zsh/
+	cp misc/zsh/_tmsu -t $(DIST_DIR)/misc/zsh/
 	tar czf $(DIST_FILE) $(DIST_DIR)
 
 install:
 	@echo
 	@echo "INSTALLING"
 	@echo
-	cp bin/tmsu $(INSTALL_DIR)
-	cp misc/bin/mount.tmsu $(MOUNT_INSTALL_DIR)
-	cp misc/bin/tmsu-* $(INSTALL_DIR)
+	mkdir -p $(INSTALL_DIR)
+	mkdir -p $(MOUNT_INSTALL_DIR)
+	cp bin/tmsu -t $(INSTALL_DIR)
+	cp misc/bin/mount.tmsu -t $(MOUNT_INSTALL_DIR)
+	cp misc/bin/tmsu-* -t $(INSTALL_DIR)
 	mkdir -p $(MAN_INSTALL_DIR)
 	gzip -fc misc/man/tmsu.1 >$(MAN_INSTALL_DIR)/tmsu.1.gz
 	mkdir -p $(ZSH_COMP_INSTALL_DIR)
-	cp misc/zsh/_tmsu $(ZSH_COMP_INSTALL_DIR)
+	cp misc/zsh/_tmsu -t $(ZSH_COMP_INSTALL_DIR)
 
 uninstall:
 	@echo "UNINSTALLING"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # installation paths
-INSTALL_DIR=/usr/bin
-MOUNT_INSTALL_DIR=/usr/sbin
-MAN_INSTALL_DIR=/usr/share/man/man1
-ZSH_COMP_INSTALL_DIR=/usr/share/zsh/site-functions
+INSTALL_DIR=$(DESTDIR)/usr/bin
+MOUNT_INSTALL_DIR=$(DESTDIR)/usr/sbin
+MAN_INSTALL_DIR=$(DESTDIR)/usr/share/man/man1
+ZSH_COMP_INSTALL_DIR=$(DESTDIR)/usr/share/zsh/site-functions
 
 # other vars
 VER=$(shell grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" src/github.com/oniony/TMSU/version/version.go)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,8 @@ DIST_NAME=tmsu-$(ARCH)-$(VER)
 DIST_DIR=$(DIST_NAME)
 DIST_FILE=$(DIST_NAME).tgz
 
-export GOPATH:=$(PWD):$(GOPATH)
+export GOPATH ?= /usr/lib/go:/usr/share/gocode
+export GOPATH := $(CURDIR):$(GOPATH)
 
 all: clean compile dist test
 


### PR DESCRIPTION
I was having some issues with TMSU installing its main binary *as* `/usr/bin` instead of *in* `/usr/bin`, so I changed the `cp` commands to be explicit about putting the files *in* directories, and added an extra 2 `mkdir -p` statements.

I also install to `$(DESTDIR)/` instead of `/`. `debuild` wasn't working without this.

Finally I add a sensible default for `GOPATH` and use `$(CURDIR)` instead of `$(PWD)`. These were both causing the following error for me:

```
CLEANING

go clean github.com/oniony/TMSU
go: GOPATH entry is relative; must be absolute path: "".
Run 'go help gopath' for usage.
Makefile:20: recipe for target 'clean' failed
```

Strangely, with GOPATH set correctly, I receive the same error if I use `export GOPATH:=$(PWD):$(GOPATH)` but not if I  use `export GOPATH:=$(CURDIR):$(GOPATH)`  (even though checking with an `@echo` shows the two as the same)