### PR TITLE
script to tag all files (not directories) under current working directory recursively

### DIFF
--- a/misc/bin/tmsu-tagall
+++ b/misc/bin/tmsu-tagall
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+usage="\
+Recursively tag all files under the current directory
+
+Usage: $(basename $0) TAG..."
+
+find . -type f -exec ls -b -Q --quoting-style=shell {} \; | xargs -i tmsu tag --tags "$1" {}


### PR DESCRIPTION
Currently, 'tmsu tag --tags "tagA tagB" [FILES]' command does not work recursively.

Recursive "ls -R" is not suitable for full path listing of files only. "ls -d -1 $PWD/**/*.*" is not complete. And the "fragments" of stdout from "find . -type f" when white spaces exist, are treated as separate filenames.

The script combines "find . -type f" for recursive full path file listing under current directory, "ls -q" for quoting in order to get rid of white spaces (and escape special character when necessary), and pipes the filenames into "tmsu tag" through xargs in a one-liner. 