### PR TITLE
Makefile: dependencies and PHONY targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,13 +35,13 @@ compile:
 
 test: unit-test integration-test
 
-unit-test:
+unit-test: compile
 	@echo
 	@echo "RUNNING UNIT TESTS"
 	@echo
 	go test github.com/oniony/TMSU/...
 
-integration-test:
+integration-test: compile
 	@echo
 	@echo "RUNNING INTEGRATION TESTS"
 	@echo
@@ -63,7 +63,7 @@ dist: compile
 	cp misc/zsh/_tmsu -t $(DIST_DIR)/misc/zsh/
 	tar czf $(DIST_FILE) $(DIST_DIR)
 
-install:
+install: compile
 	@echo
 	@echo "INSTALLING"
 	@echo
@@ -84,3 +84,5 @@ uninstall:
 	rm $(INSTALL_DIR)/tmsu-*
 	rm $(MAN_INSTALL_DIR)/tmsu.1.gz
 	rm $(ZSH_COMP_INSTALL_DIR)/_tmsu
+
+.PHONY: all clean compile test unit-test integration-test dist install uninstall


### PR DESCRIPTION
The unit and integration testing targets now depend on the
compilation target, which fixes a possible attempt to run tests before
the compilation finishes. This issue did not show up when `make compile`
(or `make dist`) was invoked before `make test` or make was run with a
single job. But using the default target with multiple jobs (e.g. `make -j 4`)
could kick off a wrong order of execution. This is now fixed. Additionally,
the install target now also depends on the compile target.

Furthermore, all makefile targets that aren't files (in this case, all
targets) are made PHONY targets, for a reasoning, see [here](https://stackoverflow.com/questions/2145590/what-is-the-purpose-of-phony-in-a-makefile) or [here](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html)
for a reasoning.