### PR TITLE
Issue #117: BLAKE2b-256 fingerprint algorithm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ go:
 install:
     - go get -u github.com/mattn/go-sqlite3
     - go get -u github.com/hanwen/go-fuse/fuse
+    - go get -u golang.org/x/crypto/blake2b

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -45,6 +45,7 @@ Linux
 
     These will be installed to your GOPATH directory (see previous step).
 
+        go get -u golang.org/x/crypto/blake2b
         go get -u github.com/mattn/go-sqlite3
         go get -u github.com/hanwen/go-fuse/fuse
 
@@ -83,13 +84,15 @@ Windows
     the graphical installer or package manager provided, if it is not installed by
     default.
 
-6. Install the dependent package
+6. Install the dependent packages
 
     This will be installed to your GOPATH directory (see step 2). The following
     command has to be run from the MinGW terminal (e.g. Msys2) otherwise it will fail
     to compile Sqlite3:
 
         go get -u github.com/mattn/go-sqlite3
+        go get -u golang.org/x/crypto/blake2b
+
 
 7. Set the path
 

--- a/src/github.com/oniony/TMSU/common/fingerprint/fingerprinter.go
+++ b/src/github.com/oniony/TMSU/common/fingerprint/fingerprinter.go
@@ -26,6 +26,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"golang.org/x/crypto/blake2b"
 )
 
 const sparseFingerprintThreshold = 5 * 1024 * 1024
@@ -68,12 +70,26 @@ func createFileFingerprint(path, algorithm string, stat os.FileInfo) (Fingerprin
 		return dynamicFingerprint(path, sha1.New(), stat.Size())
 	case "dynamic:MD5":
 		return dynamicFingerprint(path, md5.New(), stat.Size())
+	case "dynamic:BLAKE2b":
+		hash, err := blake2b.New256(nil)
+		if err != nil {
+			// Should never happen actually.
+			return "", err
+		}
+		return dynamicFingerprint(path, hash, stat.Size())
 	case "SHA256":
 		return regularFingerprint(path, sha256.New())
 	case "SHA1":
 		return regularFingerprint(path, sha1.New())
 	case "MD5":
 		return regularFingerprint(path, md5.New())
+	case "BLAKE2b":
+		hash, err := blake2b.New256(nil)
+		if err != nil {
+			// Should never happen actually.
+			return "", err
+		}
+		return regularFingerprint(path, hash)
 	case "none":
 		return Empty, nil
 	default:

--- a/src/github.com/oniony/TMSU/common/fingerprint/fingerprinter_test.go
+++ b/src/github.com/oniony/TMSU/common/fingerprint/fingerprinter_test.go
@@ -41,6 +41,11 @@ func TestSHA256Generation(test *testing.T) {
 	testCreateForLargeFile(test, "SHA256", "a4bd6407e40326c126f10412e245e4491c511636dbeddc3d2b16b41700017bc9")
 }
 
+func TestBLAKE2bGeneration(test *testing.T) {
+	testCreateForSmallFile(test, "BLAKE2b", "76b01099c5121e2436f3cb201f3917e4f46eae7dac8ac0c941b1729101e91de4")
+	testCreateForLargeFile(test, "BLAKE2b", "fdc4dc9cebbd6f162b3dad4d196646df430dbae8c547df01447285da55247087")
+}
+
 func TestDynamicMD5Generation(test *testing.T) {
 	testCreateForSmallFile(test, "dynamic:MD5", "a758071b3c2fe43c9a9b91db5077cd12")
 	testCreateForLargeFile(test, "dynamic:MD5", "668a4b622482b9fd30b1ad0eac4ab8f1")
@@ -54,6 +59,11 @@ func TestDynamicSHA1Generation(test *testing.T) {
 func TestDynamicSHA256Generation(test *testing.T) {
 	testCreateForSmallFile(test, "dynamic:SHA256", "cdf701ac9e4258a8efec453930c73d698d12d7e83c38a049a1f1a64375fbf776")
 	testCreateForLargeFile(test, "dynamic:SHA256", "0a9f9c7cd5939b04ad4bb7d14f801fe671c1b622d0e3b7769798b14dbdbf07f1")
+}
+
+func TestDynamicBLAKE2bGeneration(test *testing.T) {
+	testCreateForSmallFile(test, "dynamic:BLAKE2b", "76b01099c5121e2436f3cb201f3917e4f46eae7dac8ac0c941b1729101e91de4")
+	testCreateForLargeFile(test, "dynamic:BLAKE2b", "137c5b1e9e8107c176de7fb7a38f7670bb31364fadb2b5b883737c8732c78327")
 }
 
 func TestNoneGeneration(test *testing.T) {


### PR DESCRIPTION
I picked BLAKE2b (64-bit optimized version) with 256-bit hash size (`crypto/blake2b` docs recommend using at least this size but BLAKE2b can generate smaller hashes).
In code algorithm is named just "BLAKE2b" for brevity.

### Measurements

**TL;DR:** BLAKE2b-256 is 2 times faster than SHA-256.

SHA-256:
```
2.49user 0.54system 0:02.96elapsed 102%CPU (0avgtext+0avgdata 10972maxresident)k
0inputs+0outputs (0major+1649minor)pagefaults 0swaps
2.41user 0.54system 0:02.89elapsed 102%CPU (0avgtext+0avgdata 11032maxresident)k
0inputs+0outputs (0major+1642minor)pagefaults 0swaps
2.52user 0.44system 0:02.90elapsed 102%CPU (0avgtext+0avgdata 10916maxresident)k
0inputs+0outputs (0major+1630minor)pagefaults 0swaps
```

BLAKE2b-256:
```
1.12user 0.47system 0:01.53elapsed 103%CPU (0avgtext+0avgdata 11148maxresident)k
0inputs+0outputs (0major+1661minor)pagefaults 0swaps
1.12user 0.47system 0:01.54elapsed 103%CPU (0avgtext+0avgdata 11056maxresident)k
0inputs+0outputs (0major+1656minor)pagefaults 0swaps
1.14user 0.46system 0:01.54elapsed 103%CPU (0avgtext+0avgdata 11396maxresident)k
0inputs+0outputs (0major+1712minor)pagefaults 0swaps
```

How I measured:
```
tmsu init
tmsu config fileFingerprintAlgorithm=HASH
time tmsu tag -t "test" **
```
Test files set: 443 photos (1.1MiB - 2.7MiB, total: 753MiB) in tmpfs (you can see `0inputs+0outputs`).
Hardware: "Medium-end" Intel Haswell CPU (3.2 Ghz).
