### PR TITLE
HasOption returns true even if the Argument is empty

### DIFF
--- a/src/github.com/oniony/TMSU/cli/option.go
+++ b/src/github.com/oniony/TMSU/cli/option.go
@@ -33,6 +33,9 @@ type Options []Option
 func (options Options) HasOption(name string) bool {
 	for _, option := range options {
 		if option.LongName == name || option.ShortName == name {
+			if option.HasArgument && option.Argument == "" {
+				return false
+			}
 			return true
 		}
 	}


### PR DESCRIPTION
When an option has an argument but it is not set, HasOption would return true even if it is just the default value. This causes the call to fusermount to supply an empty list of options and appends just a string when it should pass nothing. This causes fusermount to fail.

This was tested on a recent Arch Linux with fuse 2.9.8-1