### PR TITLE
fix escaping for : characters in zsh completion

### DIFF
--- a/misc/zsh/_tmsu
+++ b/misc/zsh/_tmsu
@@ -72,7 +72,7 @@ _tmsu_tags() {
     _call_program tmsu tmsu $db tags | \
     while read tag
     do
-        local escapedTag=$tag:gs/:/\:/:gs/=/\\\\=/
+        local escapedTag=$tag:gs/:/\\:/:gs/=/\\\\=/
         tag_list+=("$escapedTag")
     done
 
@@ -87,7 +87,7 @@ _tmsu_values() {
     _call_program tmsu tmsu $db values | \
     while read value
     do
-        local escapedValue=$value:gs/:/\\\:/
+        local escapedValue=$value:gs/:/\\:/
         escapedValue=$escapedValue:gs/=/\\=/
 
         value_list+=("$escapedValue")
@@ -102,12 +102,12 @@ _tmsu_tag_values() {
     local line
 
     local tag=${PREFIX%=*}
-    local escapedTag=$tag:gs/:/\\\:/:gs/=/\\\\=/
+    local escapedTag=$tag:gs/:/\\:/:gs/=/\\\\=/
 
     _call_program tmsu tmsu $db values 2>/dev/null | \
     while read value
     do
-        local escapedValue=$value:gs/:/\\\:/
+        local escapedValue=$value:gs/:/\\:/
         escapedValue=$escapedValue:gs/=/\\=/
 
         value_list+=("$escapedTag=$escapedValue")
@@ -135,7 +135,7 @@ _tmsu_query() {
         local line
 
         local tag=${PREFIX%=*}
-        local escapedTag=$tag:gs/:/\\\:/
+        local escapedTag=$tag:gs/:/\\:/
         escapedTag=${escapedTag:gs/=/\\\\&}
         escapedTag=${escapedTag:gs/!/\\\\&}
         escapedTag=${escapedTag:gs/</\\\\&}
@@ -147,7 +147,7 @@ _tmsu_query() {
         _call_program tmsu tmsu $db values $tag2>/dev/null | \
         while read value
         do
-            local escapedValue=$value:gs/:/\\\:/
+            local escapedValue=$value:gs/:/\\:/
             escapedValue=${escapedValue:gs/=/\\\\&}
             escapedValue=${escapedValue:gs/!/\\\\&}
             escapedValue=${escapedValue:gs/</\\\\&}
@@ -166,7 +166,7 @@ _tmsu_query() {
         local line
 
         local tag=$words[$#words-2]
-        local escapedTag=$tag:gs/:/\:/
+        local escapedTag=$tag:gs/:/\\:/
         escapedTag=${escapedTag:gs/=/\\\\&}
         escapedTag=${escapedTag:gs/!/\\\\&}
         escapedTag=${escapedTag:gs/</\\\\&}
@@ -178,7 +178,7 @@ _tmsu_query() {
         _call_program tmsu tmsu $db values "$tag" | \
         while read value
         do
-            local escapedValue=$value:gs/:/\:/
+            local escapedValue=$value:gs/:/\\:/
             escapedValue=${escapedValue:gs/=/\\\\&}
             escapedValue=${escapedValue:gs/!/\\\\&}
             escapedValue=${escapedValue:gs/</\\\\&}
@@ -198,7 +198,7 @@ _tmsu_query() {
         _call_program tmsu tmsu $db tags | \
         while read tag
         do
-            local escapedTag=$tag:gs/:/\\\:/
+            local escapedTag=$tag:gs/:/\\:/
             escapedTag=${escapedTag:gs/=/\\\\&}
             escapedTag=${escapedTag:gs/!/\\\\&}
             escapedTag=${escapedTag:gs/</\\\\&}


### PR DESCRIPTION
tags with `:` in them would display incorrectly in zsh auto completion for most commands that return a list of tags.