### PR TITLE
[feature] tmsu untagged: skip dirs

### DIFF
--- a/src/github.com/oniony/TMSU/cli/untagged.go
+++ b/src/github.com/oniony/TMSU/cli/untagged.go
@@ -54,7 +54,7 @@ func untaggedExec(options Options, args []string, databasePath string) (error, w
 	paths := args
 	if len(paths) == 0 {
 		var err error
-		paths, err = directoryEntries(".")
+		paths, err = directoryEntries(".", skipDirs)
 		if err != nil {
 			return err, nil
 		}
@@ -139,7 +139,7 @@ func findUntaggedFunc(store *storage.Storage, tx *storage.Tx, paths []string, re
 		}
 
 		if recursive {
-			entries, err := directoryEntries(path)
+			entries, err := directoryEntries(path, skipDirs)
 			if err != nil {
 				return err
 			}
@@ -151,7 +151,7 @@ func findUntaggedFunc(store *storage.Storage, tx *storage.Tx, paths []string, re
 	return nil
 }
 
-func directoryEntries(path string) ([]string, error) {
+func directoryEntries(path string, skipDirs bool) ([]string, error) {
 	stat, err := os.Stat(path)
 	if err != nil {
 		switch {
@@ -178,6 +178,8 @@ func directoryEntries(path string) ([]string, error) {
 	}
 
 	names, err := dir.Readdirnames(0)
+        // readdir instead of readdirnames; then for each entry, check if it's a dir or not.
+        // If it's not, go ahead. If it is, and skipDir is set, skip IT and enter it.
 	dir.Close()
 	if err != nil {
 		return nil, fmt.Errorf("%v: could not read directory entries: %v", path, err)

--- a/src/github.com/oniony/TMSU/cli/untagged.go
+++ b/src/github.com/oniony/TMSU/cli/untagged.go
@@ -52,6 +52,8 @@ func untaggedExec(options Options, args []string, databasePath string) (error, w
 	followSymlinks := !options.HasOption("--no-dereference")
 
 	paths := args
+        // If there aren't any paths passed in
+        // then, build paths based on what directoryEntries() returns.
 	if len(paths) == 0 {
 		var err error
 		paths, err = directoryEntries(".", skipDirs)
@@ -60,6 +62,7 @@ func untaggedExec(options Options, args []string, databasePath string) (error, w
 		}
 	}
 
+        // Open up the database and prepare to commit transactions
 	store, err := openDatabase(databasePath)
 	if err != nil {
 		return err, nil
@@ -72,6 +75,8 @@ func untaggedExec(options Options, args []string, databasePath string) (error, w
 	}
 	defer tx.Commit()
 
+        // If we're merely counting..
+        // TODO: merge untagged and count functions.
 	if count {
 		count, err := findUntaggedCount(store, tx, paths, recursive, includeHidden, skipDirs, followSymlinks)
 		if err != nil {


### PR DESCRIPTION
I was having issues with `tmsu untagged` returning untagged directories, so I added a --skip-dirs option. It works with `-c` as well, returning only files either to be tagged or counted when invoked.