### PR TITLE
[Feature] untagged returns null-byte separated list

### DIFF
--- a/src/github.com/oniony/TMSU/cli/untagged.go
+++ b/src/github.com/oniony/TMSU/cli/untagged.go
@@ -153,7 +153,9 @@ func findUntaggedFunc(store *storage.Storage, tx *storage.Tx, paths []string, re
 			} else {
 			    log.Infof(2, "Skipping %v due to skipDirs.", path)
 			}
-		    }
+		    } else {
+                        action(absPath)
+                    }
 		}
 
 		if recursive {

--- a/src/github.com/oniony/TMSU/cli/untagged.go
+++ b/src/github.com/oniony/TMSU/cli/untagged.go
@@ -154,7 +154,7 @@ func findUntaggedFunc(store *storage.Storage, tx *storage.Tx, paths []string, re
 			    log.Infof(2, "Skipping %v due to skipDirs.", path)
 			}
 		    } else {
-                        action(absPath)
+			action(absPath)
                     }
 		}
 


### PR DESCRIPTION
I liked the `-0` flag that goes along with `tmsu files`; I brought that functionality into `tmsu untagged`.