### PR TITLE
Do not escape '=' when printing value names with the "values" subcommand

### DIFF
--- a/src/github.com/oniony/TMSU/cli/values.go
+++ b/src/github.com/oniony/TMSU/cli/values.go
@@ -131,12 +131,12 @@ func listValuesForTag(store *storage.Storage, tx *storage.Tx, tagName string, sh
 	} else {
 		if onePerLine {
 			for _, value := range values {
-				fmt.Println(escape(value.Name, '=', ' '))
+				fmt.Println(escape(value.Name, ' '))
 			}
 		} else {
 			valueNames := make([]string, len(values))
 			for index, value := range values {
-				valueNames[index] = escape(value.Name, '=', ' ')
+				valueNames[index] = escape(value.Name, ' ')
 			}
 
 			terminal.PrintColumns(valueNames)
@@ -172,13 +172,13 @@ func listValuesForTags(store *storage.Storage, tx *storage.Tx, tagNames []string
 			if onePerLine {
 				fmt.Println(tagName)
 				for _, value := range values {
-					fmt.Println(escape(value.Name, '=', ' '))
+					fmt.Println(escape(value.Name, ' '))
 				}
 				fmt.Println()
 			} else {
 				valueNames := make([]string, len(values))
 				for index, value := range values {
-					valueNames[index] = escape(value.Name, '=', ' ')
+					valueNames[index] = escape(value.Name, ' ')
 				}
 
 				fmt.Printf("%v: %v\n", tagName, strings.Join(valueNames, " "))

--- a/tests/values/list_values
+++ b/tests/values/list_values
@@ -3,11 +3,11 @@
 # setup
 
 touch /tmp/tmsu/file1
-tmsu tag /tmp/tmsu/file1 year=2015 year=2016    >|/tmp/tmsu/stdout 2>|/tmp/tmsu/stderr
+tmsu tag /tmp/tmsu/file1 year=2015 year=2016 'tag=v1\=v2'  >|/tmp/tmsu/stdout 2>|/tmp/tmsu/stderr
 
 # test
 
-tmsu values                                     >>/tmp/tmsu/stdout 2>>/tmp/tmsu/stderr
+tmsu values                                                >>/tmp/tmsu/stdout 2>>/tmp/tmsu/stderr
 
 # verify
 
@@ -15,6 +15,8 @@ diff /tmp/tmsu/stderr - <<EOF
 tmsu: new tag 'year'
 tmsu: new value '2015'
 tmsu: new value '2016'
+tmsu: new tag 'tag'
+tmsu: new value 'v1=v2'
 EOF
 if [[ $? -ne 0 ]]; then
     exit 1
@@ -23,6 +25,7 @@ fi
 diff /tmp/tmsu/stdout - <<EOF
 2015
 2016
+v1=v2
 EOF
 if [[ $? -ne 0 ]]; then
     exit 1

--- a/tests/values/list_values_for_tag
+++ b/tests/values/list_values_for_tag
@@ -3,11 +3,11 @@
 # setup
 
 touch /tmp/tmsu/file1
-tmsu tag /tmp/tmsu/file1 vegetable=brocolli year=2015 year=2016    >|/tmp/tmsu/stdout 2>|/tmp/tmsu/stderr
+tmsu tag /tmp/tmsu/file1 vegetable=brocolli year=2015 year=2016 'year=v1\=v2'  >|/tmp/tmsu/stdout 2>|/tmp/tmsu/stderr
 
 # test
 
-tmsu values year                                                   >>/tmp/tmsu/stdout 2>>/tmp/tmsu/stderr
+tmsu values year                                                               >>/tmp/tmsu/stdout 2>>/tmp/tmsu/stderr
 
 # verify
 
@@ -17,6 +17,7 @@ tmsu: new value 'brocolli'
 tmsu: new tag 'year'
 tmsu: new value '2015'
 tmsu: new value '2016'
+tmsu: new value 'v1=v2'
 EOF
 if [[ $? -ne 0 ]]; then
     exit 1
@@ -25,6 +26,7 @@ fi
 diff /tmp/tmsu/stdout - <<EOF
 2015
 2016
+v1=v2
 EOF
 if [[ $? -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
Escaping is undesirable for the "values" subcommand, since there is no possible ambiguity in its output (no `tag=value` is printed). It was also not consistent.

Behavior before the fix:

```
$ tmsu tag . 'foo=a\=b' 
tmsu: new value 'a=b'
$ tmsu values foo
a\=b
$ tmsu values
a=b
```

Note that `formatTagValueName` (used in `imply` and `tags`) still escapes `=`.