### PR TITLE
Dereference directory symlinks rather than only file symlinks

### DIFF
--- a/src/github.com/oniony/TMSU/cli/status.go
+++ b/src/github.com/oniony/TMSU/cli/status.go
@@ -181,8 +181,8 @@ func statusPaths(store *storage.Storage, tx *storage.Tx, paths []string, dirOnly
 			default:
 				return nil, fmt.Errorf("%v: could not stat path: %v", path, err)
 			}
-		} else if stat.Mode()&os.ModeSymlink != 0 {
-			resolvedPath, err = _path.Dereference(absPath)
+		} else {
+			resolvedPath, err = filepath.EvalSymlinks(absPath)
 			if err != nil {
 				return nil, fmt.Errorf("%v: could not dereference symbolic link: %v", path, err)
 			}

--- a/src/github.com/oniony/TMSU/cli/tag.go
+++ b/src/github.com/oniony/TMSU/cli/tag.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"github.com/oniony/TMSU/common/fingerprint"
 	"github.com/oniony/TMSU/common/log"
-	_path "github.com/oniony/TMSU/common/path"
 	"github.com/oniony/TMSU/common/text"
 	"github.com/oniony/TMSU/entities"
 	"github.com/oniony/TMSU/query"
@@ -227,12 +226,8 @@ func tagFrom(store *storage.Storage, tx *storage.Tx, fromPath string, paths []st
 		return fmt.Errorf("could not retrieve settings: %v", err), nil
 	}
 
-	stat, err := os.Lstat(fromPath)
-	if err != nil {
-		return err, nil
-	}
-	if stat.Mode()&os.ModeSymlink != 0 && followSymlinks {
-		fromPath, err = _path.Dereference(fromPath)
+	if followSymlinks {
+		fromPath, err = filepath.EvalSymlinks(fromPath)
 		if err != nil {
 			return err, nil
 		}
@@ -337,8 +332,9 @@ func tagPath(store *storage.Storage, tx *storage.Tx, path string, pairs []entiti
 		default:
 			return err
 		}
-	} else if stat.Mode()&os.ModeSymlink != 0 && followSymlinks {
-		absPath, err = _path.Dereference(absPath)
+	}
+	if followSymlinks {
+		absPath, err = filepath.EvalSymlinks(absPath)
 		if err != nil {
 			// can't honour 'force' as we don't know the target path
 			return err

--- a/src/github.com/oniony/TMSU/cli/tags.go
+++ b/src/github.com/oniony/TMSU/cli/tags.go
@@ -18,7 +18,6 @@ package cli
 import (
 	"fmt"
 	"github.com/oniony/TMSU/common/log"
-	_path "github.com/oniony/TMSU/common/path"
 	"github.com/oniony/TMSU/common/terminal"
 	"github.com/oniony/TMSU/common/terminal/ansi"
 	"github.com/oniony/TMSU/entities"
@@ -141,20 +140,16 @@ func listTagsForPaths(store *storage.Storage, tx *storage.Tx, paths []string, sh
 
 		log.Infof(2, "%v: resolving path", absPath)
 
-		stat, err := os.Lstat(absPath)
-		if err != nil {
-			switch {
-			case os.IsNotExist(err), os.IsPermission(err):
-				stat = emptyStat{}
-			default:
-				warnings = append(warnings, err.Error())
-				continue
-			}
-		} else if stat.Mode()&os.ModeSymlink != 0 && followSymlinks {
-			absPath, err = _path.Dereference(absPath)
+		if followSymlinks {
+			absPath, err = filepath.EvalSymlinks(absPath)
 			if err != nil {
-				warnings = append(warnings, err.Error())
-				continue
+				switch {
+				case os.IsNotExist(err), os.IsPermission(err):
+					// ignore
+				default:
+					warnings = append(warnings, err.Error())
+					continue
+				}
 			}
 		}
 

--- a/src/github.com/oniony/TMSU/cli/untag.go
+++ b/src/github.com/oniony/TMSU/cli/untag.go
@@ -18,7 +18,6 @@ package cli
 import (
 	"fmt"
 	"github.com/oniony/TMSU/common/log"
-	_path "github.com/oniony/TMSU/common/path"
 	"github.com/oniony/TMSU/common/text"
 	"github.com/oniony/TMSU/entities"
 	"github.com/oniony/TMSU/storage"
@@ -108,18 +107,15 @@ func untagPathsAll(store *storage.Storage, tx *storage.Tx, paths []string, recur
 
 		log.Infof(2, "%v: resolving path", path)
 
-		stat, err := os.Lstat(absPath)
-		if err != nil {
-			switch {
-			case os.IsNotExist(err), os.IsPermission(err):
-				// ignore
-			default:
-				return err, nil
-			}
-		} else if stat.Mode()&os.ModeSymlink != 0 && followSymlinks {
-			absPath, err = _path.Dereference(absPath)
+		if followSymlinks {
+			absPath, err = filepath.EvalSymlinks(absPath)
 			if err != nil {
-				return err, nil
+				switch {
+				case os.IsNotExist(err), os.IsPermission(err):
+					// ignore
+				default:
+					return err, nil
+				}
 			}
 		}
 
@@ -167,18 +163,15 @@ func untagPaths(store *storage.Storage, tx *storage.Tx, paths, tagArgs []string,
 
 		log.Infof(2, "%v: resolving path", path)
 
-		stat, err := os.Lstat(absPath)
-		if err != nil {
-			switch {
-			case os.IsNotExist(err), os.IsPermission(err):
-				// ignore
-			default:
-				return err, nil
-			}
-		} else if stat.Mode()&os.ModeSymlink != 0 && followSymlinks {
-			absPath, err = _path.Dereference(absPath)
+		if followSymlinks {
+			absPath, err = filepath.EvalSymlinks(absPath)
 			if err != nil {
-				return err, nil
+				switch {
+				case os.IsNotExist(err), os.IsPermission(err):
+					// ignore
+				default:
+					return err, nil
+				}
 			}
 		}
 

--- a/src/github.com/oniony/TMSU/cli/untagged.go
+++ b/src/github.com/oniony/TMSU/cli/untagged.go
@@ -114,7 +114,7 @@ func findUntaggedFunc(store *storage.Storage, tx *storage.Tx, paths []string, re
 		if followSymlinks {
 			log.Infof(2, "%v: resolving path", path)
 
-			absPath, err = _path.Dereference(absPath)
+			absPath, err = filepath.EvalSymlinks(absPath)
 			if err != nil {
 				return fmt.Errorf("%v: could not dereference path: %v", path, err)
 			}

--- a/src/github.com/oniony/TMSU/common/path/path.go
+++ b/src/github.com/oniony/TMSU/common/path/path.go
@@ -88,23 +88,6 @@ func UnescapeOctal(path string) string {
 	return octalEscapePattern.ReplaceAllStringFunc(path, decodeChar)
 }
 
-func Dereference(path string) (string, error) {
-	stat, err := os.Lstat(path)
-	if err != nil {
-		return "", err
-	}
-	if stat.Mode()&os.ModeSymlink != 0 {
-		path, err := os.Readlink(path)
-		if err != nil {
-			return "", err
-		}
-
-		return Dereference(path)
-	}
-
-	return path, nil
-}
-
 // unexported
 
 var octalEscapePattern = regexp.MustCompile(`\\[0-7]{3}`)


### PR DESCRIPTION
This issue was brought up as a comment in issue #154: tagging a file in a symlinked directory gives a different result depending on whether the given path is relative or absolute.