### PR TITLE
Split paths

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -41,18 +41,16 @@ Now follow the next steps according to your operating system.
 Linux
 -----
 
-4. Install the dependent packages
+4. Build and install
 
-    These will be installed to your GOPATH directory (see previous step).
+    make
+    sudo make install
 
-        go get -u golang.org/x/crypto/blake2b
-        go get -u github.com/mattn/go-sqlite3
-        go get -u github.com/hanwen/go-fuse/fuse
+    or, to compile manually:
 
-5. Build and install
-
-        make
-        sudo make install
+    mkdir bin
+    cd src/github.com/oniony/TMSU
+    go build -o ../../../../bin/tmsu .
 
     This will build the binary and copy it to `/usr/bin`, aswell as installing
     Zsh completion, a `mount` wrapper and the manual page. To adjust the paths

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ clean:
 	@echo
 	@echo "CLEANING"
 	@echo
-	go clean github.com/oniony/TMSU
+	cd src/github.com/oniony/TMSU && go clean .
 	rm -Rf bin
 	rm -Rf $(DIST_DIR)
 	rm -f $(DIST_FILE)
@@ -31,7 +31,7 @@ compile:
 	@echo "COMPILING"
 	@echo
 	@mkdir -p bin
-	go build -o bin/tmsu github.com/oniony/TMSU
+	cd src/github.com/oniony/TMSU && go build -o ../../../../bin/tmsu github.com/oniony/TMSU
 
 test: unit-test integration-test
 
@@ -39,7 +39,7 @@ unit-test: compile
 	@echo
 	@echo "RUNNING UNIT TESTS"
 	@echo
-	go test github.com/oniony/TMSU/...
+	cd src/github.com/oniony/TMSU && go test github.com/oniony/TMSU/...
 
 integration-test: compile
 	@echo

--- a/src/github.com/oniony/TMSU/cli/tag.go
+++ b/src/github.com/oniony/TMSU/cli/tag.go
@@ -43,7 +43,7 @@ var TagCommand = Command{
 
 Optionally tags applied to files may be attributed with a VALUE using the TAG=VALUE syntax.
 
-Tag and value names may consist of one or more letter, number, punctuation and symbol characters (from the corresponding Unicode categories). Tag names cannot contain the slash '/' or backslash '\' characters.
+Tag and value names may consist of one or more letter, number, punctuation and symbol characters (from the corresponding Unicode categories). Tag names cannot contain the slash '/' or backslash '\' characters. When tagging, if tag arguments contain path separators ('/' and '\'), the argument is split into parts -- this means that on Linux 'tmsu tag --tags="A/B" file.jpg' is synonymous with 'tmsu tag --tags="A B" file.jpg'.
 
 Tags will not be applied if they are already implied by tag implications. This behaviour can be overridden with the --explicit option. See the 'imply' subcommand for more information.
 
@@ -151,7 +151,13 @@ func tagExec(options Options, args []string, databasePath string) (error, warnin
 func createTagsValues(store *storage.Storage, tx *storage.Tx, tagArgs []string) (error, warnings) {
 	warnings := make(warnings, 0, 10)
 
+	processedTags := make([]string, len(tagArgs))
+	// Explode any paths
 	for _, tagArg := range tagArgs {
+		processedTags = append(processedTags, filepath.SplitList(tagArg)...)
+	}
+
+	for _, tagArg := range processedTags {
 		name := parseTagOrValueName(tagArg)
 
 		if name[0] == '=' {

--- a/src/github.com/oniony/TMSU/go.mod
+++ b/src/github.com/oniony/TMSU/go.mod
@@ -1,0 +1,9 @@
+module github.com/oniony/TMSU
+
+go 1.16
+
+require (
+	github.com/hanwen/go-fuse v1.0.0
+	github.com/mattn/go-sqlite3 v1.14.7
+	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a
+)

--- a/src/github.com/oniony/TMSU/go.sum
+++ b/src/github.com/oniony/TMSU/go.sum
@@ -1,0 +1,13 @@
+github.com/hanwen/go-fuse v1.0.0 h1:GxS9Zrn6c35/BnfiVsZVWmsG803xwE7eVRDvcf/BEVc=
+github.com/hanwen/go-fuse v1.0.0/go.mod h1:unqXarDXqzAk0rt98O2tVndEPIpUgLD9+rwFisZH3Ok=
+github.com/mattn/go-sqlite3 v1.14.7 h1:fxWBnXkxfM6sRiuH3bqJ4CfzZojMOLVc0UTsTglEghA=
+github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a h1:kr2P4QFmQr29mSLA43kwrOcgcReGTfbE9N577tCTuBc=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
+golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/tests/tag/apply_two_from_one_path
+++ b/tests/tag/apply_two_from_one_path
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# setup
+
+touch /tmp/tmsu/file1
+
+# test
+
+tmsu tag /tmp/tmsu/file1 aubergine/eggplant      >|/tmp/tmsu/stdout 2>|/tmp/tmsu/stderr
+tmsu tags --explicit /tmp/tmsu/file1            >>/tmp/tmsu/stdout 2>>/tmp/tmsu/stderr
+
+# verify
+
+diff /tmp/tmsu/stderr - <<EOF
+tmsu: new tag 'aubergine'
+tmsu: new tag 'eggplant'
+EOF
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi
+
+diff /tmp/tmsu/stdout - <<EOF
+/tmp/tmsu/file1: aubergine eggplant
+EOF
+if [[ $? -ne 0 ]]; then
+    exit 1
+fi


### PR DESCRIPTION
The TMSU doc says tags may not contain the special characters `/` or `\\`.  This patch allows users to pass in tags with slashes to TMSU tagging operations, such that TMSU treats `/` as a space.  This allows users to pass file paths to TMSU tagging without having to externally split the paths into words themselves.  An example use case using [fd](https://github.com/sharkdp/fd) to initially recursively tag all files in a directory by their directory hierarchy:

```
fd -t f --search-path Documents -j 1 -x tmsu tag "{}" {//}
```

Find all files (`-t f`) in Documents (`--search-path`) and tag the file with the relative basedir (`{//}`) of the file (`{}`). Because the tmsu executable is not thread-safe, do this in 1 thread (`-j 1`).

### Note
This is based on the Go 1.16 PR because I couldn't get TMSU to build with a contemporary version of Go with the old build system.