### PR TITLE
Mounthelper enhancements - fix setting the DB's path

### DIFF
--- a/misc/bin/mount.tmsu
+++ b/misc/bin/mount.tmsu
@@ -2,7 +2,7 @@
 
 export PATH
 
-debug=true
+debug=false
 
 # to allow other users access to the TMSU mount, enable the 'user_allow_other' option
 # in /etc/fuse.conf and then pass the 'allow_other' option below.
@@ -21,7 +21,6 @@ if [[ $4 = *"allow_other"* ]]; then
     MOUNT_OPTIONS='allow_other'
 fi
 
-# implementation based on option from #239
 if [[ $MOUNT_OPTIONS ]]; then
         tmsu mount --verbose --database "$1" "--options=${MOUNT_OPTIONS}" "$2"
     else

--- a/misc/bin/mount.tmsu
+++ b/misc/bin/mount.tmsu
@@ -16,3 +16,40 @@ if [[ $MOUNT_OPTIONS ]]; then
 else
     tmsu mount "$1" "$2"
 fi
+
+#!/usr/bin/env bash
+
+export PATH
+
+debug=true
+
+# to allow other users access to the TMSU mount, enable the 'user_allow_other' option
+# in /etc/fuse.conf and then pass the 'allow_other' option below.
+#tmsu mount options=allow_other $1 $2
+
+if [ "$debug" = "true" ]; then
+    echo 'TMSU mount helper is in debug mode!'
+
+    for arg in "$@"; do
+        echo 'Next argument:' "$arg"
+    done
+fi
+
+# Mount passes the options given after -o in the 4th argument
+if [[ $4 = *"allow_other"* ]]; then
+    MOUNT_OPTIONS='allow_other'
+fi
+
+## implementation based on `tmsu help mount` documentation
+#if [[ $MOUNT_OPTIONS ]]; then
+#    tmsu mount --verbose "--options=${MOUNT_OPTIONS}" "$1" "$2"
+#else
+#    tmsu mount --verbose "$1" "$2"
+#fi
+
+# implementation based on option from #239
+if [[ $MOUNT_OPTIONS ]]; then
+        tmsu mount --verbose --database "$1" "--options=${MOUNT_OPTIONS}" "$2"
+    else
+        tmsu mount --verbose --database "$1" "$2"
+fi

--- a/misc/bin/mount.tmsu
+++ b/misc/bin/mount.tmsu
@@ -2,25 +2,6 @@
 
 export PATH
 
-# to allow other users access to the TMSU mount, enable the 'user_allow_other' option
-# in /etc/fuse.conf and then pass the 'allow_other' option below.
-#tmsu mount --options=allow_other $1 $2
-
-# Mount passes the options given after -o in the 4th argument
-if [[ $4 = *"allow_other"* ]]; then
-    MOUNT_OPTIONS='--options=allow_other'
-fi
-
-if [[ $MOUNT_OPTIONS ]]; then
-    tmsu mount "$MOUNT_OPTIONS" "$1" "$2"
-else
-    tmsu mount "$1" "$2"
-fi
-
-#!/usr/bin/env bash
-
-export PATH
-
 debug=true
 
 # to allow other users access to the TMSU mount, enable the 'user_allow_other' option
@@ -39,13 +20,6 @@ fi
 if [[ $4 = *"allow_other"* ]]; then
     MOUNT_OPTIONS='allow_other'
 fi
-
-## implementation based on `tmsu help mount` documentation
-#if [[ $MOUNT_OPTIONS ]]; then
-#    tmsu mount --verbose "--options=${MOUNT_OPTIONS}" "$1" "$2"
-#else
-#    tmsu mount --verbose "$1" "$2"
-#fi
 
 # implementation based on option from #239
 if [[ $MOUNT_OPTIONS ]]; then

--- a/src/github.com/oniony/TMSU/cli/mount.go
+++ b/src/github.com/oniony/TMSU/cli/mount.go
@@ -33,18 +33,18 @@ var MountCommand = Command{
 	Name:     "mount",
 	Synopsis: "Mount the virtual filesystem",
 	Usages: []string{"tmsu mount",
-		"tmsu mount [OPTION]... [FILE] MOUNTPOINT"},
+		"tmsu mount [OPTION]... MOUNTPOINT"},
 	Description: `Without arguments, lists the currently mounted file-systems, otherwise mounts a virtual file-system at the path MOUNTPOINT.
 
-Where FILE is specified, the database at FILE is mounted.
+Use the --database global option or TMSU_DB environment variable (in order of precedence) to specify the path of the database to be mounted.
 
-If FILE is not specified but the TMSU_DB environment variable is defined then the database at TMSU_DB is mounted.
+Where neither --database is specified nor TMSU_DB defined then the default database is mounted.
 
-Where neither FILE is specified nor TMSU_DB defined then the default database is mounted.
+To allow other users access to the mounted filesystem, pass the 'allow_other' FUSE option, e.g. 'tmsu mount --options=allow_other mp'. (FUSE only allows the root user to use this option unless 'user_allow_other' is present in '/etc/fuse.conf'.)
 
-To allow other users access to the mounted filesystem, pass the 'allow_other' FUSE option, e.g. 'tmsu mount --options=allow_other mp'. (FUSE only allows the root user to use this option unless 'user_allow_other' is present in '/etc/fuse.conf'.)`,
+For further documentation on the usage of the --database option, refer to `tmsu help`, without specifying a subcommand`,
 	Examples: []string{"$ tmsu mount mp",
-		"$ tmsu mount /tmp/db mp",
+		"$ tmsu mount --database /tmp/db mp",
 		"$ tmsu mount --options=allow_other mp"},
 	Options: Options{Option{"--options", "-o", "mount options (passed to fusermount)", true, ""}},
 	Exec:    mountExec,


### PR DESCRIPTION
I've made some changes to the mount helper script to fix #239 , and also changed the documentation shows by `tmsu help mount`, so it shows the correct usage of the mount command.

Could you take a look please?

As you can see earlier I've modified the script so that it prints some information useful for debugging.
I've put half of that behind a variable which disables it by default, but I've kept the `--verbose` option on the TMSU command, because I didn't find a way to make it conditional while keeping the script easy to follow.
What do you think of that? Is it ok? Do you have a suggestion on how to change it?
What I tried is moving the global options into a variable, that is modified at 2 places, and referencing that variable in the commands at the bottom, but I found it unnecessarily hard to follow.