### PR TITLE
Fix untagging files via VFS

### DIFF
--- a/vfs/fusevfs.go
+++ b/vfs/fusevfs.go
@@ -503,11 +503,11 @@ func (vfs FuseVfs) Unlink(name string, context *fuse.Context) fuse.Status {
 
 	switch path[0] {
 	case tagsDir:
-		dirName := path[len(path)-2]
+		dirName := path[len(path)-3]
 
 		var tagName, valueName string
 		if dirName[0] == '=' {
-			tagName = unescape(path[len(path)-3])
+			tagName = unescape(path[len(path)-4])
 			valueName = unescape(dirName[1:])
 		} else {
 			tagName = unescape(dirName)


### PR DESCRIPTION
38227d1f moved the tagged files in the VFS to the `files` subdirectory instead of  being in the tag directory directly and it seems like the Unlink function was never updated to accomodate this.

Without this change tmsu tries to remove the `files` tag from the file (and crashes, because the tag `files` doesn't exist).