### PR TITLE
macOS Makefile

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -6,6 +6,9 @@ a downloaded binary then they can be safely ignored.
 
 1. Installing Go
 
+    * Note: macOS users can skip down to the macOS section as it includes
+      installing Go.
+
     TMSU is written in the Go programming language. To compile from source you must
     first install Go:
 
@@ -15,7 +18,7 @@ a downloaded binary then they can be safely ignored.
     available in the package management system that comes with your operating
     system.
 
-2. Set up the Go path
+3. Set up the Go path
 
     Go, as of verison 1.1, requires the `GOPATH` environment variable be set for
     the 'go get' command to function. You will need to set up a path for Go
@@ -24,7 +27,7 @@ a downloaded binary then they can be safely ignored.
 
     * <http://golang.org/cmd/go/#hdr-GOPATH_environment_variable>
 
-3. Clone the TMSU respository:
+4. Clone the TMSU respository:
 
     To clone the current stable release branch:
 
@@ -52,9 +55,54 @@ Linux
     cd src/github.com/oniony/TMSU
     go build -o ../../../../bin/tmsu .
 
-    This will build the binary and copy it to `/usr/bin`, aswell as installing
+    This will build the binary and copy it to `/usr/bin`, as well as installing
     Zsh completion, a `mount` wrapper and the manual page. To adjust the paths
     please edit the `Makefile`.
+
+macOS
+-----
+
+1. Install Homebrew
+
+    Homebrew allows you to install additional software and command-line tools
+    that macOS doesn't ship with. This is used to get GNU versions of cp and
+    find, and use them instead of macOS's BSD equivalents.
+
+    * <https://brew.sh/>
+
+    Homebrew will prompt for your password and install the Command Line Tools
+    for XCode if required. Conveniently, this also includes GNU `make` which
+    we'll also need to compile.
+
+    Homebrew will finish with instructions for putting the Homebrew downloaded
+    binaries into your local shell's PATH. Follow those instructions.
+    Note: `mount.tmsu`, a warpper for `tmsu mount`, installs into
+    `/usr/local/sbin`; you may need to adjust your `$PATH` if you'd like to use
+    it.
+
+2.  Install Go:
+
+    brew install go
+
+    Follow the instructions under Linux, for using `git clone` to pull in TMSU.
+    The source code will be pulled into the TMSU directory.
+
+3. Install GNU cp and find
+
+    These are utilities found in Homebrew's `coreutils` and `findutils`
+    packages:
+
+    brew install coreutils findutils
+
+4. Build and install
+
+    cd TMSU/
+    make
+    make install
+
+    This will build the binary and copy it to `/usr/local/bin`, as well as
+    installing Zsh completion, and a manual page. To adjust the paths please
+    edit the `Makefile`.
 
 Windows
 -------

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # installation paths
-INSTALL_DIR=$(DESTDIR)/usr/bin
-MOUNT_INSTALL_DIR=$(DESTDIR)/usr/sbin
-MAN_INSTALL_DIR=$(DESTDIR)/usr/share/man/man1
-ZSH_COMP_INSTALL_DIR=$(DESTDIR)/usr/share/zsh/site-functions
+INSTALL_DIR=$(DESTDIR)/usr/local/bin
+MOUNT_INSTALL_DIR=$(DESTDIR)/usr/local/sbin
+MAN_INSTALL_DIR=$(DESTDIR)/usr/local/share/man/man1
+ZSH_COMP_INSTALL_DIR=$(DESTDIR)/usr/local/share/zsh/site-functions
 BASH_COMP_INSTALL_DIR=$(DESTDIR)/etc/bash_completion.d
 
 # other vars
@@ -54,13 +54,13 @@ dist: compile
 	@mkdir -p $(DIST_DIR)/man
 	@mkdir -p $(DIST_DIR)/misc/zsh
 	@mkdir -p $(DIST_DIR)/misc/bash
-	cp -R bin -t $(DIST_DIR)
-	cp README.md -t $(DIST_DIR)
-	cp COPYING.md -t $(DIST_DIR)
-	cp misc/bin/* -t $(DIST_DIR)/bin/
+	gcp -R bin -t $(DIST_DIR)
+	gcp README.md -t $(DIST_DIR)
+	gcp COPYING.md -t $(DIST_DIR)
+	gcp misc/bin/* -t $(DIST_DIR)/bin/
 	gzip -fc misc/man/tmsu.1 >$(DIST_DIR)/man/tmsu.1.gz
-	cp misc/zsh/_tmsu -t $(DIST_DIR)/misc/zsh/
-	cp misc/bash/tmsu -t $(DIST_DIR)/misc/bash/
+	gcp misc/zsh/_tmsu -t $(DIST_DIR)/misc/zsh/
+	gcp misc/bash/tmsu -t $(DIST_DIR)/misc/bash/
 	tar czf $(DIST_FILE) $(DIST_DIR)
 
 install: 
@@ -72,12 +72,12 @@ install:
 	mkdir -p $(MAN_INSTALL_DIR)
 	mkdir -p $(ZSH_COMP_INSTALL_DIR)
 	mkdir -p $(BASH_COMP_INSTALL_DIR)
-	cp bin/tmsu -t $(INSTALL_DIR)
-	cp misc/bin/mount.tmsu -t $(MOUNT_INSTALL_DIR)
-	cp misc/bin/tmsu-* -t $(INSTALL_DIR)
+	gcp bin/tmsu -t $(INSTALL_DIR)
+	gcp misc/bin/mount.tmsu -t $(MOUNT_INSTALL_DIR)
+	gcp misc/bin/tmsu-* -t $(INSTALL_DIR)
 	gzip -fc misc/man/tmsu.1 >$(MAN_INSTALL_DIR)/tmsu.1.gz
-	cp misc/zsh/_tmsu -t $(ZSH_COMP_INSTALL_DIR)
-	cp misc/bash/tmsu -t $(BASH_COMP_INSTALL_DIR)
+	gcp misc/zsh/_tmsu -t $(ZSH_COMP_INSTALL_DIR)
+	gcp misc/bash/tmsu -t $(BASH_COMP_INSTALL_DIR)
 
 uninstall:
 	@echo "UNINSTALLING"

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ INSTALL_DIR=$(DESTDIR)/usr/local/bin
 MOUNT_INSTALL_DIR=$(DESTDIR)/usr/local/sbin
 MAN_INSTALL_DIR=$(DESTDIR)/usr/local/share/man/man1
 ZSH_COMP_INSTALL_DIR=$(DESTDIR)/usr/local/share/zsh/site-functions
-BASH_COMP_INSTALL_DIR=$(DESTDIR)/etc/bash_completion.d
+BASH_COMP_INSTALL_DIR=$(DESTDIR)/usr/local/etc/bash_completion.d
 
 # other vars
 VER=$(shell grep -o "[0-9]\+\.[0-9]\+\.[0-9]\+" version/version.go)

--- a/tests/runall
+++ b/tests/runall
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 if [[ -z $1 ]]; then
-    files=$( find . -mindepth 2 -perm /+x )
+    files=$( gfind . -mindepth 2 -perm /+x )
 else
-    files=$( find $1 -mindepth 1 -perm /+x )
+    files=$( gfind $1 -mindepth 1 -perm /+x )
 fi
 
 export RC=0


### PR DESCRIPTION
Includes edited Makefile paths and utilities for macOS.

COMPILING.md is also edited to include instructions for getting XCode Command Line Tools, Homebrew, Go, and GNU's make, cp, and find. Then, instructions are provided to compile.